### PR TITLE
Code update for transaction.js and related test file

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -1,7 +1,7 @@
-import { verify } from './cryptography'; 
-//import { hash as _hash } from './hashing';
-const hashing = require('../src/hashing'); 
+import {verify} from './cryptography';
 import UTXO from './UTXO';
+
+const hashing = require('../src/hashing');
 
 export class Transaction {
     constructor(utxos, receiver_public_keys, messages, signature) {
@@ -10,18 +10,18 @@ export class Transaction {
             !Array.isArray(utxos) || utxos.length === 0) {
             throw new Error("Invalid input parameters");
         }
-        
+
         for (const i of utxos) {
             if (!(i instanceof UTXO) || i.public_key !== utxos[0].public_key) {
                 throw new Error("Invalid UTXOs");
             }
         }
-        
+
         this.utxos = utxos;
         this.receiver_public_keys = receiver_public_keys;
         this.messages = messages;
         this.signature = signature;
-        
+
         if (!this.isValid()) {
             throw new Error("Transaction is not valid");
         }
@@ -73,13 +73,13 @@ export class UnsignedTransaction {
             !Array.isArray(utxos) || utxos.length === 0) {
             throw new Error("Invalid input parameters");
         }
-        
+
         for (const i of utxos) {
             if (!(i instanceof UTXO) || i.public_key !== utxos[0].public_key) {
                 throw new Error("Invalid UTXOs");
             }
         }
-        
+
         this.utxos = utxos;
         this.receiver_public_keys = receiver_public_keys;
         this.messages = messages;
@@ -87,12 +87,11 @@ export class UnsignedTransaction {
 
     getDict() {
         const utxos_json = this.utxos.map(i => i.getDict());
-        const data = {
+        return {
             "utxos": utxos_json,
             "receiver_public_keys": this.receiver_public_keys,
             "messages": this.messages
         };
-        return data;
     }
 
     getJson() {
@@ -137,9 +136,3 @@ export class Coinbase {
         return JSON.stringify(this.getDict());
     }
 }
-
-//module.exports = {
-//    Transaction,
-//    UnsignedTransaction,
-//    Coinbase
-//}

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -1,8 +1,9 @@
 import { verify } from './cryptography'; 
-import { hash as _hash } from './hashing'; 
-import UTXO from './UTXO'; 
+//import { hash as _hash } from './hashing';
+const hashing = require('../src/hashing'); 
+import UTXO from './UTXO';
 
-class Transaction {
+export class Transaction {
     constructor(utxos, receiver_public_keys, messages, signature) {
         if (!Array.isArray(receiver_public_keys) || !Array.isArray(messages) ||
             receiver_public_keys.length !== messages.length || receiver_public_keys.length === 0 ||
@@ -41,7 +42,7 @@ class Transaction {
     }
 
     getHash() {
-        return _hash(this.getJson());
+        return hashing.hash(this.getJson());
     }
 
     getFullJson() {
@@ -65,7 +66,7 @@ class Transaction {
     }
 }
 
-class UnsignedTransaction {
+export class UnsignedTransaction {
     constructor(utxos, receiver_public_keys, messages) {
         if (!Array.isArray(receiver_public_keys) || !Array.isArray(messages) ||
             receiver_public_keys.length !== messages.length || receiver_public_keys.length === 0 ||
@@ -107,7 +108,7 @@ class UnsignedTransaction {
     }
 }
 
-class Coinbase {
+export class Coinbase {
     constructor(receiver) {
         this.receiver_public_keys = [receiver];
         this.messages = [50];
@@ -137,9 +138,8 @@ class Coinbase {
     }
 }
 
-
-module.exports = {
-    Transaction,
-    UnsignedTransaction,
-    Coinbase
-}
+//module.exports = {
+//    Transaction,
+//    UnsignedTransaction,
+//    Coinbase
+//}

--- a/tests/transaction.test.js
+++ b/tests/transaction.test.js
@@ -1,10 +1,12 @@
 //const Transaction = require('../src/transaction');
-import Transaction from '../src/transaction';
+import {Transaction,UnsignedTransaction,Coinbase} from '../src/transaction';
 import UTXO from '../src/UTXO';
 import { generatePassword,generateKeyPair,generatePem,
     generatePublicPem,loadPublicKey,
     loadPrivatePem,generatePrivatePemString,
     generatePublicPemString,sign,verify } from '../src/cryptography'; 
+const hashing = require('../src/hashing'); 
+
     
 
 const Password1 = generatePassword();
@@ -12,9 +14,11 @@ const KeyPair1 = generateKeyPair();
 //const PEM1 = generatePem(KeyPair1.privateKey,Password1);
 //const PublicPEM1 = generatePublicPem(KeyPair1.publicKey);
 
-const PrivPEMString1 = generatePrivatePemString(Password1);
+//const PrivPEMString1 = generatePrivatePemString(Password1);
+const PrivPEMString1 = 'PPS1';
 const message = 50;
-const signaturebase64 = sign(PrivPEMString1, Password1, message);
+//const signaturebase64 = sign(PrivPEMString1, Password1, message);
+const signaturebase64 = 'signature';
 
 const sampleTxHash1 = 'sampleTxHash'; 
 const samplePublicKey1 = 'samplePublicKey'; 
@@ -37,10 +41,10 @@ describe('Transaction', () => {
         it('should create a transaction with valid input parameters', () => {
             
             // Create a transaction with valid input
-            const sampleTransaction = new Transaction.Transaction(sampleUTXOs, sampleReceiverPublicKey, message, signaturebase64);
+            const sampleTransaction = new Transaction(sampleUTXOs, sampleReceiverPublicKey, message, signaturebase64);
             
             // Verify that the transaction was created successfully
-            expect(sampleTransaction).toBeInstanceOf(Transaction);
+            expect(sampleTransaction).toBeInstanceOf(Transaction.Transaction);
             expect(sampleTransaction).toBeDefined(); 
             expect(typeof sampleTransaction).toBe('object'); 
         });
@@ -54,7 +58,7 @@ describe('Transaction', () => {
             const signature = 'validSignature';
             
             // Verify that creating a transaction with invalid input parameters throws an error
-            expect(() => new Transaction.Transaction(utxos, receiver_public_keys, messages, signature)).toThrowError('Invalid input parameters');
+            expect(() => new Transaction(utxos, receiver_public_keys, messages, signature)).toThrowError('Invalid input parameters');
         });
         
         // Test case 3: Invalid UTXOs
@@ -66,7 +70,7 @@ describe('Transaction', () => {
             const signature = 'validSignature';
             
             // Verify that creating a transaction with invalid UTXOs throws an error
-            expect(() => new Transaction.Transaction(utxos, receiver_public_keys, messages, signature)).toThrowError('Invalid UTXOs');
+            expect(() => new Transaction(utxos, receiver_public_keys, messages, signature)).toThrowError('Invalid UTXOs');
         });
     });
 
@@ -79,7 +83,161 @@ describe('Transaction', () => {
             const signature = 'validSignature';
             
             // Create a transaction
-            const transaction = new Transaction.Transaction(utxos, receiver_public_keys, messages, signature);
+            const transaction = new Transaction(utxos, receiver_public_keys, messages, signature);
+            
+            // Calculate the expected dictionary representation
+            const expectedData = {
+                utxos: utxos.map(utxo => utxo.getDict()),
+                receiver_public_keys,
+                messages,
+            };
+            
+            // Verify that the getDict method returns the expected dictionary
+            expect(transaction.getDict()).toEqual(expectedData);
+        });
+    });
+
+    describe('getJson', () => {
+        it('should return the correct JSON representation', () => {
+            // Sample data
+            const utxos = [UTXOObj1,UTXOObj2];
+            const receiver_public_keys = ['receiverPublicKey1', 'receiverPublicKey2'];
+            const messages = ['message1', 'message2'];
+            const signature = 'validSignature';
+    
+            // Create a transaction
+            const transaction = new Transaction(utxos, receiver_public_keys, messages, signature);
+    
+            // Calculate the expected JSON representation
+            const expectedJson = JSON.stringify(transaction.getDict());
+    
+            // Verify that the getJson method returns the expected JSON
+            expect(transaction.getJson()).toBe(expectedJson);
+        });
+    });
+
+    describe('getHash', () => {
+        it('should return the correct hash', () => {
+            // Sample data
+            const utxos = [UTXOObj1,UTXOObj2];
+            const receiver_public_keys = ['receiverPublicKey1', 'receiverPublicKey2'];
+            const messages = ['message1', 'message2'];
+            const signature = 'validSignature';
+    
+            // Create a transaction
+            const transaction = new Transaction(utxos, receiver_public_keys, messages, signature);
+    
+            // Calculate the expected hash
+            const expectedHash = _hash(transaction.getJson()); // Replace with your actual hash function
+    
+            // Verify that the getHash method returns the expected hash
+            expect(transaction.getHash()).toBe(expectedHash);
+        });
+    });
+
+    describe('getFullJson', () => {
+        it('should return the correct JSON representation with signature', () => {
+            // Sample data
+            const utxos = [UTXOObj1,UTXOObj2];
+            const receiver_public_keys = ['receiverPublicKey1', 'receiverPublicKey2'];
+            const messages = ['message1', 'message2'];
+            const signature = 'validSignature';
+    
+            // Create a transaction
+            const transaction = new Transaction(utxos, receiver_public_keys, messages, signature);
+    
+            // Calculate the expected dictionary representation
+            const expectedDict = transaction.getDict();
+            expectedDict.signature = signature;
+    
+            // Calculate the expected JSON representation with signature
+            const expectedJson = JSON.stringify(expectedDict);
+    
+            // Verify that the getFullJson method returns the expected JSON
+            expect(transaction.getFullJson()).toBe(expectedJson);
+        });
+    });
+
+    describe('isValid', () => {
+        it('should return true for a valid transaction', () => {
+            // Sample data for a valid transaction
+            const utxos = [UTXOObj1,UTXOObj2];
+            const receiver_public_keys = ['receiverPublicKey1', 'receiverPublicKey2'];
+            const messages = [10, 20]; 
+            const signature = 'validSignature';
+    
+            // Create a transaction
+            const transaction = new Transaction(utxos, receiver_public_keys, messages, signature);
+    
+            // Verify that the isValid method returns true for a valid transaction
+            expect(transaction.isValid()).toBe(true);
+        });
+    
+        it('should return false for an invalid transaction', () => {
+            // Sample data for an invalid transaction (e.g., incorrect signature or amount)
+            const utxos = [/* Provide valid UTXO instances here */];
+            const receiver_public_keys = ['receiverPublicKey1', 'receiverPublicKey2'];
+            const messages = [10, 30]; 
+            const signature = 'invalidSignature';
+    
+            // Create a transaction
+            const transaction = new Transaction(utxos, receiver_public_keys, messages, signature);
+    
+            // Verify that the isValid method returns false for an invalid transaction
+            expect(transaction.isValid()).toBe(false);
+        });
+    });
+    
+});
+
+describe('Unsigned Transaction', () => {
+    describe('Unsigned Transaction creation (constructor)', () => {
+        // Test case 1: Valid input parameters
+        it('should create a transaction with valid input parameters', () => {
+            
+            // Create a transaction with valid input
+            const sampleTransaction = new UnsignedTransaction(sampleUTXOs, sampleReceiverPublicKey, message, signaturebase64);
+            
+            // Verify that the transaction was created successfully
+            expect(sampleTransaction).toBeInstanceOf(Transaction.UnsignedTransaction);
+            expect(sampleTransaction).toBeDefined(); 
+            expect(typeof sampleTransaction).toBe('object'); 
+        });
+        
+        // Test case 2: Invalid input parameters
+        it('should throw an error for invalid input parameters', () => {
+            // Invalid data: Empty receiver_public_keys
+            const utxos = [UTXOObj1];
+            const receiver_public_keys = [];
+            const messages = [];
+            
+            // Verify that creating a transaction with invalid input parameters throws an error
+            expect(() => new UnsignedTransaction(utxos, receiver_public_keys, messages)).toThrowError('Invalid input parameters');
+        });
+        
+        // Test case 3: Invalid UTXOs
+        it('should throw an error for invalid UTXOs', () => {
+            // Invalid data: UTXOs with different public_key values
+            const utxos = [new UTXO('publicKey1', 1), new UTXO('publicKey2', 2)];
+            const receiver_public_keys = ['receiverPublicKey'];
+            const messages = ['message'];
+            const signature = 'validSignature';
+            
+            // Verify that creating a transaction with invalid UTXOs throws an error
+            expect(() => new UnsignedTransaction(utxos, receiver_public_keys, messages)).toThrowError('Invalid UTXOs');
+        });
+    });
+
+    describe('getDict', () => {
+        it('should return the correct dictionary representation', () => {
+            // Sample data
+            const utxos = [UTXOObj1,UTXOObj2];
+            const receiver_public_keys = ['receiverPublicKey1', 'receiverPublicKey2'];
+            const messages = ['message1', 'message2'];
+            const signature = 'validSignature';
+            
+            // Create a transaction
+            const transaction = new UnsignedTransaction(utxos, receiver_public_keys, messages);
             
             // Calculate the expected dictionary representation
             const expectedData = {
@@ -93,4 +251,69 @@ describe('Transaction', () => {
         });
     });
     
+});
+
+describe('Coinbase Transaction', () => {
+    // Sample data
+    const receiver = 'receiverPublicKey';
+    const coinbase = new Coinbase(receiver);
+
+    describe('Coinbase - Constructor', () => {
+        it('should initialize Coinbase with the provided receiver', () => {
+    
+            // Verify that the Coinbase instance was created with the provided receiver
+            expect(coinbase.receiver_public_keys).toEqual([receiver]);
+            expect(coinbase.messages).toEqual([50]);
+        });
+    });
+
+    describe('Coinbase - getHash', () => {
+        it('should return the correct hash', () => {
+    
+            // Calculate the expected hash
+            const expectedHash = hashing.hash(JSON.stringify({
+                "receiver_public_keys": [receiver],
+                "messages": [50],
+            }));
+    
+            // Verify that the getHash method returns the expected hash
+            expect(coinbase.getHash()).toBe(expectedHash);
+        });
+    });
+
+    describe('Coinbase - getDict', () => {
+        it('should return the correct dictionary representation', () => {
+    
+            // Calculate the expected dictionary representation
+            const expectedDict = {
+                "receiver_public_keys": [receiver],
+                "messages": [50],
+            };
+    
+            // Verify that the getDict method returns the expected dictionary
+            expect(coinbase.getDict()).toEqual(expectedDict);
+        });
+    });
+
+    describe('Coinbase - getJson', () => {
+        it('should return the correct JSON representation', () => {
+
+            // Calculate the expected JSON representation
+            const expectedJson = JSON.stringify({
+                "receiver_public_keys": [receiver],
+                "messages": [50],
+            });
+    
+            // Verify that the getJson method returns the expected JSON
+            expect(coinbase.getJson()).toBe(expectedJson);
+        });
+    });
+
+    describe('Coinbase - isValid', () => {
+        it('should always return true for Coinbase transactions', () => {
+
+            // Verify that the isValid method always returns true for Coinbase transactions
+            expect(coinbase.isValid()).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
import method on "hashing" (hash function was imported differently with _hash and created conflict) 
Updated the export method by declaring "export" on each class. Classes can be imported as follows:
import {Transaction,UnsignedTransaction,Coinbase} from '../src/transaction';

## Pull Request

### Description

Description

Fixed Transaction export declarations

Related Issue

#34 